### PR TITLE
Update runtime.txt

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7
+python-3.7.2


### PR DESCRIPTION
to fix
`Requested runtime ("python-3.7.1") is not available for this stack (heroku-18)` in heroku
because Python 3.7.1 is not supported by Heroku